### PR TITLE
Np add pipeline metadata tsv to genomics screening

### DIFF
--- a/pipelines/cohort_screening/VariantAnnotation.wdl
+++ b/pipelines/cohort_screening/VariantAnnotation.wdl
@@ -6,6 +6,7 @@ workflow AnnotateVCFWorkflow {
         File bed_file
         String cloud_provider
         Int batch_size
+        String output_prefix
     }
 
     # Determine docker prefix based on cloud provider
@@ -59,7 +60,9 @@ workflow AnnotateVCFWorkflow {
     call VariantReport {
         input:
             positions_annotation_json = AnnotateVCF.positions_annotation_json,
-            docker_path = docker_prefix + variantreport_docker_image
+            docker_path = docker_prefix + variantreport_docker_image,
+            output_prefix = output_prefix,
+            bed_file = bed_file
     }
 
     output {
@@ -358,6 +361,8 @@ task VariantReport {
 
     input {
         Array[File] positions_annotation_json
+        File bed_file
+        String output_prefix
 
         String docker_path
         Int memory_mb = 4000
@@ -382,7 +387,9 @@ task VariantReport {
             echo "Creating the report for $sample_id"
             python3 /src/variants_report.py \
             --positions_json $json \
-            --sample_identifier $sample_id
+            --sample_identifier $sample_id \
+            --output_prefix ~{output_prefix} \
+            --bed_file ~{bed_file}
         done
 
     >>>

--- a/pipelines/cohort_screening/VariantAnnotation.wdl
+++ b/pipelines/cohort_screening/VariantAnnotation.wdl
@@ -26,7 +26,7 @@ workflow AnnotateVCFWorkflow {
 
     # Define docker images
     String nirvana_docker_image = "nirvana:np_add_nirvana_docker"
-    String variantreport_docker_image = "variantreport:latest"
+    String variantreport_docker_image = "genomics_variant_report:5af8bc6"
 
 
     call BatchVCFs as batch_vcfs {

--- a/pipelines/cohort_screening/VariantAnnotation.wdl
+++ b/pipelines/cohort_screening/VariantAnnotation.wdl
@@ -27,7 +27,7 @@ workflow AnnotateVCFWorkflow {
 
     # Define docker images
     String nirvana_docker_image = "nirvana:np_add_nirvana_docker"
-    String variantreport_docker_image = "genomics_variant_report:5af8bc6"
+    String variantreport_docker_image = "genomics_variant_report:0e50556"
 
 
     call BatchVCFs as batch_vcfs {

--- a/pipelines/genomics_screening/GenomicsScreening.wdl
+++ b/pipelines/genomics_screening/GenomicsScreening.wdl
@@ -29,7 +29,7 @@ workflow GenomicsScreening {
 
     # Define docker images
     String nirvana_docker_image = "nirvana:np_add_nirvana_docker"
-    String variantreport_docker_image = "genomics_variant_report:5af8bc6"
+    String variantreport_docker_image = "genomics_variant_report:0e50556"
 
 
     call BatchVCFs as batch_vcfs {

--- a/pipelines/genomics_screening/GenomicsScreening.wdl
+++ b/pipelines/genomics_screening/GenomicsScreening.wdl
@@ -428,28 +428,23 @@ task PipelineMetadata {
     command <<<
 
         # Variables
-        pipeline_version=~{pipeline_version}
+        pipeline_version=v~{pipeline_version}
         declare -a input_vcfs=(~{sep=' ' input_vcfs})
         declare -a pdf_reports=(~{sep=' ' pdf_report})
 
-        # Write the basename of the pdf_report to the file
-        echo "This pipeline metadata was used to generate following variant report PDFs:" >> pipeline_metadata.txt
-        for pdf in "${input_pdfs[@]}"; do
-            basename_pdf=$(basename "$pdf")
-            echo "$basename_pdf" >> pipeline_metadata.txt
+        echo -e "input_vcf\tvariant_report_pdf" >> ~{output_prefix}_pipeline_metadata.tsv
+
+        for ((i=0; i<${#pdf_reports[@]}; i++)); do
+            basename_pdf=$(basename "${pdf_reports[i]}")
+            basename_vcf=$(basename "${input_vcfs[i]}")
+            echo -e "$basename_vcf\t$basename_pdf" >> ~{output_prefix}_pipeline_metadata.tsv
         done
-        echo "" >> pipeline_metadata.txt
+
+        echo "" >> ~{output_prefix}_pipeline_metadata.tsv
 
         # Write the pipeline version to the file
-        echo "Pipeline Version: $pipeline_version" >> pipeline_metadata.txt
-        echo "" >> pipeline_metadata.txt
-
-        # Write the input VCFs to the file
-        echo "Input VCFs:" >> pipeline_metadata.txt
-        for vcf in "${input_vcfs[@]}"; do
-            basename_vcf=$(basename "$vcf")
-            echo "$basename_vcf" >> pipeline_metadata.txt
-        done
+        date=$(date)
+        echo "The variant report PDFs were generated on $date using the $pipeline_version version of this pipeline" >> ~{output_prefix}_pipeline_metadata.tsv
 
     >>>
     runtime {
@@ -459,7 +454,7 @@ task PipelineMetadata {
         disks: 'local-disk ${disk_size_gb} HDD'
     }
     output {
-        File pipeline_metadata = "~{output_prefix}_pipeline_metadata.json"
+        File pipeline_metadata = "~{output_prefix}_pipeline_metadata.tsv"
     }
 }
 

--- a/pipelines/genomics_screening/GenomicsScreening.wdl
+++ b/pipelines/genomics_screening/GenomicsScreening.wdl
@@ -71,7 +71,8 @@ workflow GenomicsScreening {
             pipeline_version = pipeline_version,
             output_prefix = output_prefix,
             input_vcfs = input_vcfs,
-            pdf_report = VariantReport.pdf_report
+            pdf_report = VariantReport.pdf_report,
+            bed_file = bed_file
     }
 
     output {
@@ -420,6 +421,7 @@ task PipelineMetadata {
         String output_prefix
         Array[File] input_vcfs
         Array[File] pdf_report
+        File bed_file
 
         String memory_mb = 4000
         String disk_size_gb = 10
@@ -432,19 +434,20 @@ task PipelineMetadata {
         declare -a input_vcfs=(~{sep=' ' input_vcfs})
         declare -a pdf_reports=(~{sep=' ' pdf_report})
 
-        echo -e "input_vcf\tvariant_report_pdf" >> ~{output_prefix}_pipeline_metadata.tsv
+        echo -e "input_vcf\tvariant_report_pdf" >> ~{output_prefix}_pipeline_metadata.txt
 
         for ((i=0; i<${#pdf_reports[@]}; i++)); do
             basename_pdf=$(basename "${pdf_reports[i]}")
             basename_vcf=$(basename "${input_vcfs[i]}")
-            echo -e "$basename_vcf\t$basename_pdf" >> ~{output_prefix}_pipeline_metadata.tsv
+            echo -e "$basename_vcf\t$basename_pdf" >> ~{output_prefix}_pipeline_metadata.txt
         done
 
-        echo "" >> ~{output_prefix}_pipeline_metadata.tsv
+        echo "" >> ~{output_prefix}_pipeline_metadata.txt
 
         # Write the pipeline version to the file
         date=$(date)
-        echo "The variant report PDFs were generated on $date using the $pipeline_version version of this pipeline" >> ~{output_prefix}_pipeline_metadata.tsv
+        bed_file=$(basename ~{bed_file})
+        echo "The variant report PDFs were generated on $date using the $bed_file file and $pipeline_version version of this pipeline" >> ~{output_prefix}_pipeline_metadata.txt
 
     >>>
     runtime {
@@ -454,7 +457,7 @@ task PipelineMetadata {
         disks: 'local-disk ${disk_size_gb} HDD'
     }
     output {
-        File pipeline_metadata = "~{output_prefix}_pipeline_metadata.tsv"
+        File pipeline_metadata = "~{output_prefix}_pipeline_metadata.txt"
     }
 }
 

--- a/pipelines/genomics_screening/GenomicsScreening.wdl
+++ b/pipelines/genomics_screening/GenomicsScreening.wdl
@@ -29,7 +29,7 @@ workflow GenomicsScreening {
 
     # Define docker images
     String nirvana_docker_image = "nirvana:np_add_nirvana_docker"
-    String variantreport_docker_image = "genomics_variant_report:675560f"
+    String variantreport_docker_image = "genomics_variant_report:5af8bc6"
 
 
     call BatchVCFs as batch_vcfs {


### PR DESCRIPTION
gcp run here: https://app.terra.bio/#workspaces/warp-pipelines/np-genomics-screening/job_history/4ccd3c0a-33b1-4bfc-9b30-12c3bc49ab8d

new tsv output for pipeline metadata looks like: 

```
input_vcf	variant_report_pdf
HG002_GRCh38_GIAB_1_22_v4.2.1_benchmark.broad-header.vcf.gz	acmg_HG002_GRCh38_GIAB_1_22_v4.2.1_benchmark.broad-header_acmg_variants_report.pdf
gnomad_pathogenic_test.v2.vcf	acmg_gnomad_pathogenic_test.v2_acmg_variants_report.pdf

The variant report PDFs were generated on Mon Jun 10 22:33:36 UTC 2024 using the acmg_without_patches.bed file and v1.0 version of this pipeline
