### PR TITLE
[FE-258] fix key error caused by missing array brackets

### DIFF
--- a/pipelines/cohort_screening/src/variants_report.py
+++ b/pipelines/cohort_screening/src/variants_report.py
@@ -104,7 +104,7 @@ def filter_transcripts(positions):
             for variant_dict in position[variants_field]:
                 if transcripts_field in variant_dict and len(variant_dict[transcripts_field]) > 1:
                     sorted_transcripts = sorted(variant_dict[transcripts_field], key=lambda x: x['transcript'])
-                    variant_dict[transcripts_field] = sorted_transcripts[0]
+                    variant_dict[transcripts_field] = [sorted_transcripts[0]]
         progress_bar.set_description('Selecting first transcript when sorted alphabetically...')
         progress_bar.update(1)
 

--- a/pipelines/genomics_screening/src/variants_report.py
+++ b/pipelines/genomics_screening/src/variants_report.py
@@ -104,7 +104,7 @@ def filter_transcripts(positions):
             for variant_dict in position[variants_field]:
                 if transcripts_field in variant_dict and len(variant_dict[transcripts_field]) > 1:
                     sorted_transcripts = sorted(variant_dict[transcripts_field], key=lambda x: x['transcript'])
-                    variant_dict[transcripts_field] = sorted_transcripts[0]
+                    variant_dict[transcripts_field] = [sorted_transcripts[0]]
         progress_bar.set_description('Selecting first transcript when sorted alphabetically...')
         progress_bar.update(1)
 


### PR DESCRIPTION
GenomicScreening.wdl workflow was failing with this error in the VariantReport task
```
traceback (most recent call last):
File "/src/variants_report.py", line 457, in <module>
report(args)
File "/src/variants_report.py", line 444, in report
mapped_variants = map_variants_to_table(variants_to_include)
File "/src/variants_report.py", line 299, in map_variants_to_table
"gene": variant["variants"][0]["transcripts"][0]["hgnc"],
KeyError: 0
```